### PR TITLE
Fix parser compatibility for Godot stable

### DIFF
--- a/TacoEmpire/scripts/systems/DemandSimulator.gd
+++ b/TacoEmpire/scripts/systems/DemandSimulator.gd
@@ -57,7 +57,9 @@ func _find_segment(hour_of_day: float) -> Dictionary:
         var end := int(segment.get("end_hour", 24))
         if hour_of_day >= start and hour_of_day <= end:
             return segment
-    return _segments.is_empty() ? {} : _segments[0]
+    if _segments.is_empty():
+        return {}
+    return _segments[0]
 
 func _maybe_trigger_drizzle() -> void:
     if _drizzle_config.is_empty():

--- a/TacoEmpire/scripts/systems/GameState.gd
+++ b/TacoEmpire/scripts/systems/GameState.gd
@@ -38,7 +38,13 @@ func _ready() -> void:
     SaveLoad.register_provider(self)
     set_process(true)
 
-func register_scene(placement: PlacementSystem, production_node: Production, hud_node: Node, upgrades_node: Node, tutorial_node: Node) -> void:
+func register_scene(
+        placement: PlacementSystem,
+        production_node: Production,
+        hud_node: Node,
+        upgrades_node: Node,
+        tutorial_node: Node
+    ) -> void:
     placement_system = placement
     production = production_node
     hud = hud_node
@@ -104,7 +110,9 @@ func _load_json(file_name: String) -> Dictionary:
     var content := file.get_as_text()
     file.close()
     var parsed := JSON.parse_string(content)
-    return typeof(parsed) == TYPE_DICTIONARY ? parsed : {}
+    if typeof(parsed) == TYPE_DICTIONARY:
+        return parsed
+    return {}
 
 func _start_or_load() -> void:
     var saved := SaveLoad.load_game()

--- a/TacoEmpire/scripts/world/PlacementGhost.gd
+++ b/TacoEmpire/scripts/world/PlacementGhost.gd
@@ -9,7 +9,10 @@ func update_preview(system: PlacementSystem, cell: Vector2i, size: Vector2i, is_
     var world_pos := system.grid_to_world(cell)
     position = world_pos
     polygon.scale = Vector2(max(1, size.x), max(1, size.y))
-    polygon.modulate = is_valid ? Color(0.3, 0.9, 0.3, 0.5) : Color(0.9, 0.2, 0.2, 0.5)
+    if is_valid:
+        polygon.modulate = Color(0.3, 0.9, 0.3, 0.5)
+    else:
+        polygon.modulate = Color(0.9, 0.2, 0.2, 0.5)
     visible = true
 
 func hide_preview() -> void:


### PR DESCRIPTION
## Summary
- split the `GameState.register_scene` declaration over multiple lines to avoid parser issues
- replace ternary expressions with standard if/else blocks in the runtime scripts to keep compatibility with older Godot 4 builds

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca08b07a048326a50bf25e94cacd1f